### PR TITLE
fix(material/bottom-sheet): add `height` `minHeight` `maxHeight` to c…

### DIFF
--- a/src/material/bottom-sheet/bottom-sheet-config.ts
+++ b/src/material/bottom-sheet/bottom-sheet-config.ts
@@ -72,4 +72,13 @@ export class MatBottomSheetConfig<D = any> {
 
   /** Scroll strategy to be used for the bottom sheet. */
   scrollStrategy?: ScrollStrategy;
+
+  /** Height for the bottom sheet. */
+  height?: string = '';
+
+  /** Minimum height for the bottom sheet. If a number is provided, assumes pixel units. */
+  minHeight?: number | string;
+
+  /** Maximum height for the bottom sheet. If a number is provided, assumes pixel units. */
+  maxHeight?: number | string;
 }

--- a/src/material/bottom-sheet/bottom-sheet.spec.ts
+++ b/src/material/bottom-sheet/bottom-sheet.spec.ts
@@ -461,6 +461,24 @@ describe('MatBottomSheet', () => {
     expect(scrollStrategy.enable).toHaveBeenCalled();
   });
 
+  it('should contain the height style properties on overlay pane', () => {
+    bottomSheet.open(PizzaMsg, {
+      panelClass: 'height--pane',
+      height: '300px',
+      maxHeight: 400, // this is converted into pixels
+      minHeight: 200, // this is converted into pixels
+    });
+
+    viewContainerFixture.detectChanges();
+
+    const paneElement = overlayContainerElement.querySelector('.height--pane') as HTMLElement;
+
+    expect(paneElement).toBeTruthy();
+    expect(paneElement.style.height).toBe('300px');
+    expect(paneElement.style.maxHeight).toBe('400px');
+    expect(paneElement.style.minHeight).toBe('200px');
+  });
+
   describe('passing in data', () => {
     it('should be able to pass in data', () => {
       const config = {

--- a/tools/public_api_guard/material/bottom-sheet.md
+++ b/tools/public_api_guard/material/bottom-sheet.md
@@ -64,6 +64,9 @@ export class MatBottomSheetConfig<D = any> {
     direction?: Direction;
     disableClose?: boolean;
     hasBackdrop?: boolean;
+    height?: string;
+    maxHeight?: number | string;
+    minHeight?: number | string;
     panelClass?: string | string[];
     restoreFocus?: boolean;
     scrollStrategy?: ScrollStrategy;


### PR DESCRIPTION
…onfig (#29794)

these properties were missing from the config but still worked as they were passed to dialog under the hood to avoid type errors

fixes #28832